### PR TITLE
Keep hero image inline in synced Medium posts

### DIFF
--- a/_posts/2025-03-18-Speculative-Design-From-Taboo-to-Technology-Why-Farts-Might-Be-Worth-Harnessing.md
+++ b/_posts/2025-03-18-Speculative-Design-From-Taboo-to-Technology-Why-Farts-Might-Be-Worth-Harnessing.md
@@ -28,6 +28,29 @@ Farting is often the punchline of a joke — an embarrassing, smelly fact of
 
 ### Challenging a Cultural&nbsp;Taboo
 
+![](https://cdn-images-1.medium.com/max/1024/1*qaei5Yt8ilp-Vccw-8ug7A.png)
+_He-Gassen (屁合戦) — A humorous 19th-century Japanese scroll illustrating “fart battles,” showing that some cultures have approached flatulence with comedic artwork rather than strict taboo._
+
+In most contemporary Western societies, flatulence is considered impolite or embarrassing. However, attitudes vary historically and globally. For example, in **19th-century Japan** , comedic artwork like the _He-Gassen_ (“Fart Battle”) scroll depicted people using flatulence as a playful weapon. While not a full endorsement of farting in every context, it shows that certain art forms openly joked about or depicted flatulence without the same level of taboo. Similarly, **Le Pétomane** (Joseph Pujol) became a famous French stage performer in the late 19th century by entertaining audiences with his “art” of controlled flatulence — a reminder that, in some comedic traditions, passing gas could be a central attraction rather than a forbidden topic.
+
+These examples don’t necessarily mean entire cultures fully “approve” of public farting, but they demonstrate that the strict hush-hush treatment so common in many parts of the world isn’t universal. **Speculative design**  — a practice that encourages us to see everyday objects and systems in radically new ways — prods us to imagine: what if we looked at our own bodies’ by-products as a resource rather than an inconvenience?
+
+By reframing something culturally off-limits into a design challenge, we spark conversations on broader themes: the value of human waste, the quest for eco-friendly solutions, and the willingness of society to embrace unconventional ideas. **Speculative design** takes note of these pockets of acceptance (or at least humour) and asks: if we can talk about it, maybe we can harness&nbsp;it.
+
+### Hidden Energy Potential
+
+Despite its comedic reputation, a fart is a small but tangible emission of gas. It often contains methane, hydrogen, carbon dioxide, and other compounds that — if collected in large quantities — can be combusted or used in chemical reactions to produce electricity. Indeed, capturing methane is standard practice on farms and in landfills, where organic matter decomposes to form&nbsp;biogas.
+
+![](https://cdn-images-1.medium.com/max/1024/1*TWUhtYV1eWXJeWL6UkayOw.png)
+_Ieropoulos, I. A., Greenman, J., & Melhuish, C. (2013). “Urinal tryst: how microbial fuel cells can harness urine to generate electricity.” Bioinspiration & Biomimetics, 8(4)._
+
+Shifting that large-scale approach to personal flatulence might seem outlandish, but speculative design invites us to consider how tiny individual contributions, taken together, could power small electronics or sensors. The crucial idea is transforming bodily waste from an object of laughter or shame into a resource that fits within larger sustainability goals.
+
+In _Dune_, Frank Herbert envisions a harsh desert world where survival hinges on conserving every drop of moisture. The Fremen — inhabitants of the sandy planet Arrakis — rely on “stillsuits,” specialized desert overalls designed to reclaim bodily fluids like sweat and exhaled vapour. These suits are a fusion of practicality and ingenuity, capturing and filtering moisture so that even in an arid, life-threatening environment, its wearers can remain hydrated. The stillsuits not only reflect the Fremen’s deep respect for water as a precious resource but also emphasize the broader theme of ecological balance that runs throughout the&nbsp;story.
+
+![](https://cdn-images-1.medium.com/max/1024/1*2qlOv-6oBmh1FoukAD8GlA.png)
+_Herbert, F. (1965). Dune. Chilton Books. (Concept of stillsuits as moisture-recycling garments.)_
+
 This idea parallels how speculative designs might one day harness other bodily by-products, including flatulence, to create energy in resource-limited environments. Much like the stillsuit’s water-recycling function, a “fart reactor” concept seeks to transform what we ordinarily dismiss as waste into a vital, sustainable resource. Both examples illustrate how necessity and ingenuity can merge to reshape our relationship with our own bodies’ outputs — and potentially redefine survival in extreme conditions.
 
 ### Why Now?

--- a/_posts/2025-04-15-Speculative-Design-Inside-the-Fart-Reactor-A-Look-at-the-Hypothetical-Mechanics.md
+++ b/_posts/2025-04-15-Speculative-Design-Inside-the-Fart-Reactor-A-Look-at-the-Hypothetical-Mechanics.md
@@ -36,6 +36,9 @@ Welcome to the second article in our series on speculative bioenergy design. In 
 **Why This Matters**  
  Human flatulence isn’t high in volume or pressure, so capturing every small emission is crucial. A tight seal and efficient odor control ensure minimal leakage while keeping the device discreet.
 
+![](https://cdn-images-1.medium.com/max/1024/1*K2eXp7JBsxQPHWCtaePXug.png)
+_Concept of a Fart Reactor wearable device_
+
 ### Converting Gas to Electricity
 
 Since the pressure and volume of human flatulence are quite low, **traditional mechanical methods** (like spinning turbines) are largely impractical. Instead, we look to the following well-researched avenues:

--- a/_posts/2025-05-07-Speculative-Design-Breaking-the-Silence-Social-and-Cultural-Impacts-of-BodyPowered-Devices.md
+++ b/_posts/2025-05-07-Speculative-Design-Breaking-the-Silence-Social-and-Cultural-Impacts-of-BodyPowered-Devices.md
@@ -75,6 +75,9 @@ If a “fart reactor” ever gained commercial traction, it might be championed 
 
 In some speculative futures, a personal biogas device could become a badge of environmental commitment. Much like driving a hybrid car can signal one’s values, wearing a body-powered device might project eco-savviness. Alternatively, it might remain niche, only championed by sustainability hobbyists or outliers comfortable challenging social&nbsp;norms.
 
+![](https://cdn-images-1.medium.com/max/1024/1*bIO4bo0dVtS7gVhmOCb7og.png)
+_It became a norm_
+
 ### 5. Looking&nbsp;Ahead
 
 Body-powered devices will likely provoke a broad spectrum of responses — from humour and acceptance to mockery or outright rejection. Yet, by leaning into comedy, emphasizing privacy, and highlighting genuine environmental benefits, designers can carve a path toward **mainstream understanding**  — if not universal adoption. The more we talk openly about these concepts, the easier it becomes to break down cultural barriers and spark creative thinking about renewable energy at the most personal&nbsp;level.

--- a/_posts/2025-06-09-Speculative-Design-Beyond-Farts-Other-HumanBased-Bioenergy-Innovations.md
+++ b/_posts/2025-06-09-Speculative-Design-Beyond-Farts-Other-HumanBased-Bioenergy-Innovations.md
@@ -78,6 +78,8 @@ Piezoelectric devices convert mechanical energy, such as footsteps or muscle mov
 **Impact**  
 Piezoelectric energy capture integrates seamlessly into daily routines, providing passive, continuous energy to support urban infrastructure and wearable technology.
 
+![](https://cdn-images-1.medium.com/max/1024/1*_j8Wwj1i5xYxQeS5hh8hvw.png)
+
 ### Why These Innovations Matter
 
 Human-based bioenergy innovations, while initially strange or speculative, underline a crucial shift: what we consider waste or mere bodily functions can become valuable renewable resources. Such innovations:

--- a/_posts/2025-12-10-Speculative-Design-Design-Challenges-Comfort-efficiency-and-privacy-concerns.md
+++ b/_posts/2025-12-10-Speculative-Design-Design-Challenges-Comfort-efficiency-and-privacy-concerns.md
@@ -42,6 +42,9 @@ To address this, experts urge strict safeguards. Workers should be allowed to op
 
 Harnessing human power is a poetic idea: every step, every heartbeat, every breath could keep our devices alive. But until designers solve the “big three” — comfort, efficiency, and privacy — these gadgets risk being novelties rather than necessities. The future will likely come not from squeezing out one more microwatt, but from _rethinking the contract between humans and machines_: how much energy we can give, how much data we should share, and how much discomfort we’re willing to endure. Speculative design reminds us that technology is never just technical — it’s also ethical, social, and deeply&nbsp;human.
 
+![](https://cdn-images-1.medium.com/max/1024/1*qzSsBjTRbVTx5ZVqVbnJxg.png)
+_Speculative Design | Design Challenges: Comfort, efficiency, and privacy concerns_
+
 ### References
 
 [1]: “[Stretchable thermoelectric generators with enhanced output by infrared&nbsp;…](https://www.sciencedirect.com/science/article/pii/S1385894722052287)”

--- a/_posts/2026-03-02-I-Built-a-Tool-to-Outsmart-the-Lottery-Spoiler-The-Lottery-Still-Wins.md
+++ b/_posts/2026-03-02-I-Built-a-Tool-to-Outsmart-the-Lottery-Spoiler-The-Lottery-Still-Wins.md
@@ -24,6 +24,9 @@ I wasn’t trying to crack some code. I know the math. Every draw is independent
 
 But here’s the thing — even if you can’t predict the future, you can make more **_informed_** choices. And honestly? It’s just way more fun to play when you have data backing your picks instead of your birthday.
 
+![](https://cdn-images-1.medium.com/max/1024/1*IsGud7qrukygv_DyuoZoHw.png)
+_So far, I am negative 18e 😅_
+
 ### **From Curiosity to a Full&nbsp;Product**
 
 What started as a weekend experiment turned into something I actually use every week. And then I thought — if I find this useful, maybe other players would&nbsp;too.

--- a/_posts/2026-04-04-I-Built-a-ClosedLoop-AI-Planning-System-With-Claude-Obsidian-and-800-Lines-of-Python.md
+++ b/_posts/2026-04-04-I-Built-a-ClosedLoop-AI-Planning-System-With-Claude-Obsidian-and-800-Lines-of-Python.md
@@ -85,6 +85,9 @@ DayWatch is the piece I had to build because it didn’t&nbsp;exist.
 
 It’s a system tray app (800 lines of Python) that watches my daily plan file and sends native desktop notifications when time blocks are about to start. Click the tray icon and you see your day at a&nbsp;glance:
 
+![](https://cdn-images-1.medium.com/max/751/1*eNmJbkZhn6TGeI06vI8ytg.png)
+_Example of a daily plan. (PS: My Saturdays don’t look like this 😅.)_
+
 Five minutes before each block starts: a notification. When the block starts: another notification. If I launch the app mid-block: an immediate “you should be doing X right now” notification. If I edit the plan in Obsidian: instant reload, rescheduled notifications.
 
 It’s built with Claude Code, which is ironic and appropriate — Claude plans my day, and Claude built the tool that enforces the&nbsp;plan.

--- a/_posts/2026-04-07-I-Built-a-KarpathyStyle-Knowledge-Wiki-From-8-Months-of-Obsidian-Notes-Heres-How.md
+++ b/_posts/2026-04-07-I-Built-a-KarpathyStyle-Knowledge-Wiki-From-8-Months-of-Obsidian-Notes-Heres-How.md
@@ -86,6 +86,9 @@ The immediate difference: I can now ask Claude “what’s the relationship betw
 
 But the deeper change is philosophical. My notes used to be write-only — useful the day I wrote them, then slowly decaying into noise. Now every note, every conversation, every web clip feeds into a living knowledge base that gets richer over time. Karpathy’s phrase captures it perfectly: explorations and queries always “add&nbsp;up.”
 
+![](https://cdn-images-1.medium.com/max/818/1*eAGRyk4DuhhPUURapDFGsw.png)
+_wiki graph_
+
 ### How You Can Do&nbsp;This
 
 You don’t need anything fancy. Here’s the&nbsp;minimum:

--- a/_posts/2026-04-24-The-Carry-Counter-How-I-Made-My-Procrastination-Countable.md
+++ b/_posts/2026-04-24-The-Carry-Counter-How-I-Made-My-Procrastination-Countable.md
@@ -138,4 +138,5 @@ That is what a productivity system is&nbsp;for.
 
 _If you run something similar, or something better, I’d love to hear how you handle the carry. Writing about it is, in itself, one of the items that kept getting carried on my list. This post is a 3× that finally&nbsp;shipped._
 
+![](https://cdn-images-1.medium.com/max/1024/1*ZQ0XTWL81UC9khuOrsmYZg.jpeg)
  ![](https://medium.com/_/stat?event=post.clientViewed&referrerSource=full_rss&postId=fcc78ae18b60)

--- a/_posts/2026-05-04-The-Quiet-Outage.md
+++ b/_posts/2026-05-04-The-Quiet-Outage.md
@@ -62,6 +62,9 @@ The lesson is one I’ve now relearned three or four times in my career, and it 
 
 After the incident, the first thing I did was promote that counter to the dashboard. The second thing I did was add four others I’d noticed during the diagnosis but had similarly never bothered to chart. The third thing I did was accept that I will probably do this again next quarter, because incidents teach you about the metrics you should have had, and there is no shortcut to knowing which ones those&nbsp;are.
 
+![](https://cdn-images-1.medium.com/max/1024/1*hW8EPRd1a54OArFdPGE0-w.png)
+_metrics from busypipe.com_
+
 ### The temptation to&nbsp;rewrite
 
 I want to spend a moment on this, because it’s the part most postmortems leave&nbsp;out.

--- a/medium_to_md.rb
+++ b/medium_to_md.rb
@@ -35,9 +35,6 @@ feed.entries.each do |e|
 
 	tags = e.categories.join(', ')
 	original_link = e.url
-	
-	# Medium feed includes the hero image in the `content` field. Since Jekyll and other systems will probably render the hero image separately, remove it from the HTML before generating the Markdown
-	content.sub!(/<figure><img\salt="([\w\.\-])?"\ssrc="https:\/\/cdn-images-1.medium.com\/max\/[0-9]+\/[0-9]\*[0-9a-zA-Z._-]+"\s\/>(\<figcaption\>.*\<\/figcaption\>)?<\/figure>/, '')
 
 	result = ReverseMarkdown.convert(content).gsub(/\\n/,"\n")
 


### PR DESCRIPTION
## Summary

- Stops stripping the first `<figure>` from RSS content in `medium_to_md.rb`. The post layout never rendered `page.background`, so for any Medium article with a single image (every post since May 2025), the synced page ended up with zero visible images.
- Re-syncs the 10 RSS-sourced posts so their hero image now appears inline near the top of the body. `background:` front matter is unchanged.
- Side benefit: the `2025-03-18` post recovers several paragraphs of content and two figures that the previous greedy `(<figcaption>.*</figcaption>)?` regex had silently consumed (it spanned from the first to the last figcaption when multiple figures had captions).

## Test plan
- [ ] `bundle exec jekyll serve` and confirm the hero image renders on each regenerated post (e.g. `/2026/05/04/The-Quiet-Outage`)
- [ ] Confirm the blog index thumbnails (driven by `post.background`) still render correctly
- [ ] Spot-check `2025-03-18-Speculative-Design-From-Taboo-to-Technology...` to confirm the restored body content reads correctly
- [ ] Confirm next Medium sync (`.github/workflows/sync-medium.yml`) produces a new post with hero image inline